### PR TITLE
Added fallback for self.pattern

### DIFF
--- a/plugin/rg.vim
+++ b/plugin/rg.vim
@@ -98,7 +98,7 @@ function! s:RunRg(cmd)
         let cmd_options = g:rg_command . " " . a:cmd
       endif
     endif
-    call s:RunCmd(cmd_options, "")
+    call s:RunCmd(cmd_options, a:cmd)
     return
   endif
   let pattern = input("Search for pattern: ")


### PR DESCRIPTION
When you call `:Rg foobarfizzbuzz`, and it doesn't exist, the error message is `Error: Pattern  not found`. This PR does a fallback to show the whole command instead.

Now the command errors with `Error: Pattern rg --vimgrep -t vim asdfasdasdf not found`.

I also had a variant of this where it shows the whole command, without adding an artificial `pattern` argument. I could make a PR for that instead, if you prefer. The output of that could look like `Error: Pattern --vimgrep -t vim asdfasdasdf not found`