### PR TITLE
Remove the last entry, which is always invalid text

### DIFF
--- a/plugin/rg.vim
+++ b/plugin/rg.vim
@@ -35,7 +35,7 @@ function! s:RgEvent(job_id, data, event) dict
   let msg = "Error: Pattern " . self.pattern . " not found"
   if a:event == "stdout"
     let s:chunks[-1] .= a:data[0]
-    call extend(s:chunks, a:data[1:])
+    call extend(s:chunks, a:data[1:-1])
   elseif a:event == "on_stderr"
     let s:error = 1
     call s:Alert(msg)

--- a/plugin/rg.vim
+++ b/plugin/rg.vim
@@ -31,11 +31,27 @@ function! s:ShowResults(data)
   let s:chunks = [""]
 endfunction
 
+function! s:RemoveTrailingEmptyLines(lines)
+  let l:last_index_with_text = -1
+
+  for l:item in a:lines
+    if l:item != ""
+      let l:last_index_with_text += 1
+    endif
+  endfor
+
+  if l:last_index_with_text == -1
+    return a:lines
+  endif
+
+  return a:lines[0:l:last_index_with_text]
+endfunction
+
 function! s:RgEvent(job_id, data, event) dict
   let msg = "Error: Pattern " . self.pattern . " not found"
   if a:event == "stdout"
     let s:chunks[-1] .= a:data[0]
-    call extend(s:chunks, a:data[1:-2])
+    call extend(s:chunks, a:data[1:])
   elseif a:event == "on_stderr"
     let s:error = 1
     call s:Alert(msg)
@@ -54,7 +70,7 @@ function! s:RgEvent(job_id, data, event) dict
       return
     endif
     call s:Alert("")
-    call s:ShowResults(s:chunks)
+    call s:ShowResults(s:RemoveTrailingEmptyLines(s:chunks))
   endif
 endfunction
 

--- a/plugin/rg.vim
+++ b/plugin/rg.vim
@@ -35,7 +35,7 @@ function! s:RgEvent(job_id, data, event) dict
   let msg = "Error: Pattern " . self.pattern . " not found"
   if a:event == "stdout"
     let s:chunks[-1] .= a:data[0]
-    call extend(s:chunks, a:data[1:-1])
+    call extend(s:chunks, a:data[1:-2])
   elseif a:event == "on_stderr"
     let s:error = 1
     call s:Alert(msg)


### PR DESCRIPTION
When searching, the last entry in the quick-fix list is blank. This PR omits it

## Before
![Screenshot from 2023-10-30 22-37-57](https://github.com/duane9/nvim-rg/assets/10103049/64b1a24e-38ca-4406-8652-6db15b9cd961)

## After
![Screenshot from 2023-10-30 22-37-37](https://github.com/duane9/nvim-rg/assets/10103049/0e8bbd36-a675-4c9f-9c97-59dad264b579)

This works because the last entry appears to always be a newline, which of course setqflist doesn't know how to process. That said, assuming that the last entry is always invalid isn't great. If you'd like, I can check for an empty string first and then remove it if found. Up to you!

Edit: Apparently the last line is not always an empty string. When it's not, removing the last index actually removes a valid search result. So instead strip the trailing empty lines before they get displayed.