### PR TITLE
Added context + title information to the generated Quick Fix window

### DIFF
--- a/plugin/rg.vim
+++ b/plugin/rg.vim
@@ -23,8 +23,9 @@ function! s:Alert(msg)
   echohl WarningMsg | echomsg a:msg | echohl None
 endfunction
 
-function! s:ShowResults(data)
+function! s:ShowResults(data, title)
   call setqflist([])
+  call setqflist([], 'r', {'context': 'file_search', 'title': a:title})
   caddexpr a:data
   copen
   let s:chunks = [""]
@@ -126,7 +127,7 @@ function! s:RgEvent(job_id, data, event) dict
       return
     endif
     call s:Alert("")
-    call s:ShowResults(s:RemoveTrailingEmptyLine(s:chunks))
+    call s:ShowResults(s:RemoveTrailingEmptyLine(s:chunks), "Rg: " . self.pattern)
   endif
 endfunction
 
@@ -157,7 +158,7 @@ function! s:RunCmd(cmd, pattern)
     call s:Alert(l:msg)
     return
   endif
-  call s:ShowResults(l:cmd_output)
+  call s:ShowResults(l:cmd_output, a:pattern)
 endfunction
 
 function! s:RunRg(cmd)

--- a/plugin/rg.vim
+++ b/plugin/rg.vim
@@ -127,7 +127,7 @@ function! s:RgEvent(job_id, data, event) dict
       return
     endif
     call s:Alert("")
-    call s:ShowResults(s:RemoveTrailingEmptyLine(s:chunks), "Rg: " . self.pattern)
+    call s:ShowResults(s:RemoveTrailingEmptyLine(s:chunks), self.cmd)
   endif
 endfunction
 
@@ -146,7 +146,8 @@ function! s:RunCmd(cmd, pattern)
     \ "on_stdout": function("s:RgEvent"),
     \ "on_stderr": function("s:RgEvent"),
     \ "on_exit": function("s:RgEvent"),
-    \ "pattern": a:pattern
+    \ "pattern": a:pattern,
+    \ "cmd": a:cmd
     \ }
     let s:rg_job = jobstart(a:cmd, l:opts)
     return
@@ -158,7 +159,7 @@ function! s:RunCmd(cmd, pattern)
     call s:Alert(l:msg)
     return
   endif
-  call s:ShowResults(l:cmd_output, a:pattern)
+  call s:ShowResults(l:cmd_output, a:cmd)
 endfunction
 
 function! s:RunRg(cmd)


### PR DESCRIPTION
If you have a winbar enabled on the QuickFix window, nvim-rg currently just displays `:setqflist()`. It could be more descriptive though, which is what I'd like to add via this PR

### Before
![nvim-rg_before_title_and_context](https://github.com/duane9/nvim-rg/assets/10103049/56116fda-6550-40d5-9ef8-b11e8cbb409c)

### After 1 - A Named Title
![nvim-rg_after_1_title_and_context png](https://github.com/duane9/nvim-rg/assets/10103049/03b3002f-cc6f-4805-a45f-335d5db81dc9)

### After 2 - A Raw Query
![nvim-rg_after_2_title_and_context png png](https://github.com/duane9/nvim-rg/assets/10103049/b3e1287e-108d-4276-8d56-5a083ce16f33)

I'm not actually sure why there's 2 possible "Afters". It seems to be random chance whether it is one or the other. Possibly it's an artifact of how the async logic works or maybe there's a bug that could be improved. Hard to say. If you have suggestions on this point I can look into it.